### PR TITLE
Simplify crypto config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,17 @@ sshd_ssh_protocol_version: 2
 sshd_log_level: VERBOSE # default: INFO
 
 # Ciphers and keying
-sshd_keyexchange_algorithms: diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256
-sshd_ciphers: aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-sshd_macs: hmac-sha2-512,hmac-sha2-256
+sshd_keyexchange_algorithms:
+  - diffie-hellman-group-exchange-sha256
+  - diffie-hellman-group16-sha512
+  - ecdh-sha2-nistp521
+  - ecdh-sha2-nistp384
+  - ecdh-sha2-nistp256
+sshd_ciphers:
+  - aes256-gcm@openssh.com
+  - aes128-gcm@openssh.com
+  - aes256-ctr,aes192-ctr
+  - aes128-ctr
+sshd_macs:
+  - hmac-sha2-512
+  - hmac-sha2-256

--- a/tasks/set_crypto_algorithms.yml
+++ b/tasks/set_crypto_algorithms.yml
@@ -1,23 +1,15 @@
 ---
 
-- name: set ciphers
+- name: Configure crypto settings
   ansible.builtin.lineinfile:
     dest: '{{ sshd_config_filepath }}'
     state: present
-    regex: '#?^Ciphers '
-    line: 'Ciphers {{ sshd_ciphers }}'
-
-- name: set key exchange algorithm
-  ansible.builtin.lineinfile:
-    dest: '{{ sshd_config_filepath }}'
-    state: present
-    regex: '#?^KexAlgorithms '
-    line: 'KexAlgorithms {{ sshd_keyexchange_algorithms }}'
-
-- name: set key exchange algorithm
-  ansible.builtin.lineinfile:
-    dest: '{{ sshd_config_filepath }}'
-    state: present
-    regex: '#?^MACs '
-    line: 'MACs {{ sshd_macs }}'
-
+    regex: '#?^{{ item.key }} '
+    line: '{{ item.key }} {{ item.value }}'
+  loop:
+    - key: Ciphers
+      value: '{{ sshd_ciphers | join(",") }}'
+    - key: KexAlgorithms
+      value: '{{ sshd_keyexchange_algorithms | join(",") }}'
+    - key: MACs
+      value: '{{ sshd_macs | join(",") }}'


### PR DESCRIPTION
This patch simplifies the applied crypto config and ensures that the code passes `yamllint` and `ansible-lint`.

In particular, this:

- Uses a loop for the settings instead of repeating the same type of task multiple times.
- Turns the list of algorithms into an actual list
- Let's the task name start with an uppercase character