### PR TITLE
Introduce linter

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,24 @@
+---
+
+name: Ansible lint
+
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install dependencies
+        run: >
+          pip3 install
+          ansible-lint
+          yamllint
+
+      - run: ansible-lint
+
+      - run: yamllint .

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 sshd_config_filepath: /etc/ssh/sshd_config
 
 # General SSH settings

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: restart sshd
+- name: Restart sshd
   ansible.builtin.service:
     name: sshd
     state: restarted

--- a/tasks/disable_global_crypto_config.yml
+++ b/tasks/disable_global_crypto_config.yml
@@ -1,9 +1,11 @@
 ---
 
-- name: disable globaly crypto config for sshd on RedHat >= 8
+- name: Disable globaly crypto config for sshd on RedHat >= 8
   ansible.builtin.lineinfile:
     dest: /etc/sysconfig/sshd
     regexp: '^CRYPTO_POLICY='
     line: 'CRYPTO_POLICY='
-  notify: restart sshd
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8
+  notify: Restart sshd
+  when: >
+    ansible_os_family == 'RedHat'
+    and ansible_distribution_major_version | int >= 8

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
-- import_tasks: set_general_settings.yml
-- import_tasks: set_crypto_algorithms.yml
-- import_tasks: disable_global_crypto_config.yml
+- name: Configure general SSHd settings
+  ansible.builtin.import_tasks: set_general_settings.yml
+- name: Configure crypto algorithms
+  ansible.builtin.import_tasks: set_crypto_algorithms.yml
+- name: Disable global crypto configuration
+  ansible.builtin.import_tasks: disable_global_crypto_config.yml

--- a/tasks/set_general_settings.yml
+++ b/tasks/set_general_settings.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: set ssh version explicit
+- name: Set ssh version explicit
   ansible.builtin.lineinfile:
     path: '{{ sshd_config_filepath }}'
     state: present
@@ -8,7 +8,7 @@
     regex: '^#?Protocol'
     line: 'Protocol {{ sshd_ssh_protocol_version }}'
 
-- name: set log level to {{ sshd_log_level }}
+- name: Set log level to {{ sshd_log_level }}
   ansible.builtin.lineinfile:
     path: '{{ sshd_config_filepath }}'
     state: present


### PR DESCRIPTION
This pull request introduces `ansible-lint` and `yamllint` which will be automatically run on new patches via GitHub Actions. These are the default linters used by many ansible projects.

The workflow will fail without #3 and #4 being merged.