### PR TITLE
Add Galaxy Metadata to be able to install this role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: secure_sshd
+  namespace: uos_rz
+  author: René-Maximilian Malsky
+  description: Ansible role to harden the sshd configuration
+  company: Osnabrück University
+  license: BSD-3-Clause
+  min_ansible_version: "2.10"
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: Ubuntu
+      versions:
+        - jammy
+dependencies: []


### PR DESCRIPTION
Right now, if you add this role as dependency to your `requirements.yml` like this:

```yaml
  - src: https://github.com/UOS-RZ/secure_sshd.git
    scm: git
    version: next
```

…and then try installing the dependencies, you end up with aan error like this:

```
[WARNING]: - secure_sshd was NOT installed successfully: this role does not appear to have a meta/main.yml file.
```

This patch adds the missing metadata file and you should be able to install this role after merging this patch.