### PR TITLE
Login Configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,14 @@ sshd_ciphers:
 sshd_macs:
   - hmac-sha2-512
   - hmac-sha2-256
+
+# If login as user `root` is permitted.
+# For more details, take a look at PermitRootLogin in the sshd_config man page.
+# Valid options are: yes, prohibit-password, forced-commands-only, or no
+sshd_root_login: prohibit-password
+
+# If password authentication is permitted.
+# More details at PasswordAuthentication in the sshd_config man page.
+# Valid options are `yes` or `no`
+# Warning: Ensure these values are quoted in yaml.
+sshd_password_login: 'no'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,5 +4,7 @@
   ansible.builtin.import_tasks: set_general_settings.yml
 - name: Configure crypto algorithms
   ansible.builtin.import_tasks: set_crypto_algorithms.yml
+- name: Configure login options
+  ansible.builtin.import_tasks: set_login.yml
 - name: Disable global crypto configuration
   ansible.builtin.import_tasks: disable_global_crypto_config.yml

--- a/tasks/set_login.yml
+++ b/tasks/set_login.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Configure login settings
+  ansible.builtin.lineinfile:
+    dest: '{{ sshd_config_filepath }}'
+    state: present
+    regex: '#?^{{ item.key }} '
+    line: '{{ item.key }} {{ item.value }}'
+  loop:
+    - key: PermitRootLogin
+      value: '{{ sshd_root_login }}'
+    - key: PasswordAuthentication
+      value: '{{ sshd_password_login }}'


### PR DESCRIPTION
This patch adds default configuration for root and password logins and makes it easy for users to overwrite these settings.

Logins as `root` are permitted by default using an SSH key, but not using a password. While disabling this entirely is often a good idea, settings that as default could easily lock out users by accident.

Using passwords for login is generally a bad idea and people should use SSH keys anyway. Disabling this by default should not hurt.