### PR TITLE
No config includes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,9 @@ sshd_root_login: prohibit-password
 # Valid options are `yes` or `no`
 # Warning: Ensure these values are quoted in yaml.
 sshd_password_login: 'no'
+
+# If managed by ansible, we should be able to set all settings in
+# the main sshd_config file. So we can disable the loading of other
+# sshd config files in order to avoid unwanted overrides.
+# E.g. cloud-init might override the PasswordAuthentication setting.
+sshd_no_includes: true

--- a/tasks/set_general_settings.yml
+++ b/tasks/set_general_settings.yml
@@ -14,3 +14,11 @@
     state: present
     regex: '^#?LogLevel'
     line: 'LogLevel {{ sshd_log_level }}'
+
+- name: Disable loading of other sshd config files
+  ansible.builtin.lineinfile:
+    dest: '{{ sshd_config_filepath }}'
+    regexp: '^Include \/etc\/ssh\/sshd_config\.d\/\*\.conf'
+    line: '#Include /etc/ssh/sshd_config.d/*.conf'
+  notify: Restart sshd
+  when: sshd_no_includes


### PR DESCRIPTION
If managed by ansible, we should be able to set all settings in the main sshd_config file. So we can disable the loading of other sshd config files in order to avoid unwanted overrides. E.g. cloud-init might override the PasswordAuthentication setting.