### PR TITLE
Handle yamllint warnings

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,4 +21,4 @@ jobs:
 
       - run: ansible-lint
 
-      - run: yamllint .
+      - run: yamllint --strict .

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ sshd_config_filepath: /etc/ssh/sshd_config
 
 # General SSH settings
 sshd_ssh_protocol_version: 2
-sshd_log_level: VERBOSE # default: INFO
+sshd_log_level: VERBOSE
 
 # Ciphers and keying
 sshd_keyexchange_algorithms:


### PR DESCRIPTION
This patch turns yamllint warnings into errors when running the CI tests and fixes the (single) current warning. This way, GitHub does not complain on every pull request.