### PR TITLE
Provide a full example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Then include the role in your playbook:
     - role: secure_sshd
 ```
 
+For a full example playbook with step-by-step instructions, take a look at
+
+- [Example Ansible playbook including secure\_sshd](https://github.com/UOS-RZ/secure_sshd/tree/example.playbook)
+
 ## Configuration options
 
 Take a look at the [defaults](defaults/main.yml) to see what variables you can set.


### PR DESCRIPTION
This patch links the full example playbook documenting how to use this role which now lives in the `example-playbook` branch.