### PR TITLE
Fix openssh-server name on Ubuntu

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: Restart sshd
   ansible.builtin.service:
-    name: sshd
+    name: "{{ 'ssh' if ansible_os_family == 'Debian' else 'sshd' }}"
     state: restarted


### PR DESCRIPTION
Debian and Ubuntu call their openssh-server `ssh` and not `sshd`. They had `sshd` as an alias, but this seem to not always be the case on newer Ubuntu versions.