### PR TITLE
Adopt ansible_facts namespacing for future compatibility

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: Restart sshd
   ansible.builtin.service:
-    name: "{{ 'ssh' if ansible_os_family == 'Debian' else 'sshd' }}"
+    name: "{{ 'ssh' if ansible_facts['os_family'] == 'Debian' else 'sshd' }}"
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,4 +28,4 @@
     regexp: '^CRYPTO_POLICY='
     line: 'CRYPTO_POLICY='
   notify: Restart sshd
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'


### PR DESCRIPTION
Replace deprecated top-level fact variables with ansible_facts dictionary access. Required for Ansible 2.24+ when INJECT_FACTS_AS_VARS defaults to False.